### PR TITLE
Ajout de metadonnées avec un json pour zenodo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -75,7 +75,7 @@
       "resource_type": "dataset"
     },
     {
-      "identifier": "10.22033/ESGF/CMIP6.604",
+      "identifier": "10.22033/ESGF/CMIP6.608",
       "relation": "isDerivedFrom",
       "resource_type": "dataset"
     },

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,97 @@
+{
+  "title": "CRCM5-CMIP6 : A dynamically-downscaled ensemble of CMIP6 simulations.",
+  "creators": [
+    {
+      "name": "Paquin, Dominique",
+      "affiliation": "Ouranos Consortium, Montréal, Québec, Canada",
+      "orcid": "0000-0002-1353-930X"
+    },
+    {
+      "name": "Giguère, Michel",
+      "affiliation": "Ouranos Consortium, Montréal, Québec, Canada",
+    },
+    {
+      "name": "McCray, Christopher",
+      "affiliation": "Ouranos Consortium, Montréal, Québec, Canada",
+      "orcid": "0000-0001-5594-9115"
+    },
+    {
+      "name": "Asselin, Olivier",
+      "affiliation": "Ouranos Consortium, Montréal, Québec, Canada",
+      "orcid": "0000-0003-3621-2737"
+    },
+    {
+      "name": "Gauthier, Charles",
+      "affiliation": "Ouranos Consortium, Montréal, Québec, Canada",
+      "orcid": "0000-0003-1580-3335"
+    },
+    {
+      "name": "Matte, Dominic",
+      "affiliation": "Ouranos Consortium, Montréal, Québec, Canada",
+      "orcid": "0000-0002-9670-9318"
+    }
+    {
+      "name": "Labonté, Marie-Pier",
+      "affiliation": "Ouranos Consortium, Montréal, Québec, Canada",
+      "orcid": "0000-0003-0738-3940"
+    },
+    {
+      "name": "Bourgault, Pascal",
+      "affiliation": "Ouranos Consortium, Montréal, Québec, Canada",
+      "orcid": "0000-0003-1192-0403"
+    }
+  ],
+  "keywords": [
+    "climate",
+    "Regional climate",
+    "Regional climate model",
+    "CORDEX",
+
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "10.1007/s00382-013-1778-9",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication"
+    },
+    {
+      "identifier": "10.1007/s00382-013-1737-5",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication"
+    },
+    {
+      "identifier": "10.22033/ESGF/CMIP6.1317",
+      "relation": "isDerivedFrom",
+      "resource_type": "dataset"
+    },
+    {
+      "identifier": "10.22033/ESGF/CMIP6.15349",
+      "relation": "isDerivedFrom",
+      "resource_type": "dataset"
+    },
+    {
+      "identifier": "10.22033/ESGF/CMIP6.1395",
+      "relation": "isDerivedFrom",
+      "resource_type": "dataset"
+    },
+    {
+      "identifier": "10.22033/ESGF/CMIP6.604",
+      "relation": "isDerivedFrom",
+      "resource_type": "dataset"
+    },
+    {
+      "identifier": "10.24381/cds.143582cf",
+      "relation": "isDerivedFrom",
+      "resource_type": "dataset"
+    }
+  ],
+  "license": "cc-by-4.0",
+  "language": "eng",
+  "communities": [
+    {
+      "identifier": "ouranos"
+    }
+  ],
+  "upload_type": "dataset",
+  "access_right": "open"
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # CRCM-CMIP
 [![DOI](https://zenodo.org/badge/790831449.svg)](https://zenodo.org/doi/10.5281/zenodo.11061924)
 
-[Ouranos](https://www.ouranos.ca/en)
-Canadian Regional Climate Model – version 5.
+[Ouranos](https://www.ouranos.ca/en) : Canadian Regional Climate Model – version 5
 
 **Martynov et al. 2013, Separovic et al. 2013**
 
@@ -34,6 +33,16 @@ Prescribed SST & sea ice fraction
 
 #### Aerosols
 Prescribed
+
+### Data Access
+Due to its large size, the full dataset can't yet be shared publicly.
+
+A subset of the variables are stored on Ouranos' THREDDS server.
+
+- Annual files : https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/birdhouse/disk2/ouranos/CORDEX/catalog.html
+- Aggregated datasets : https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/datasets/simulations/RCM-CMIP6/catalog.html
+
+Other variables can be provided upon request by writing to simulations_ouranos@ouranos.ca.
 
 ### Acknowlegments
 Developed by the [ESCER Centre](https://escer.uqam.ca/) at UQAM (Université du Québec à Montréal) with the collaboration


### PR DESCRIPTION
- Ajout des auteurs. J'ai mis tout SAC pour le moment, je laisse @dompaq décider.
- Ajout des pilotes dans les entrées "related" avec la relation "isDerivedFrom". J'ai déjà mis NorESM2-MM.
- Ajout des deux articles de description (Martynov et al. 2013, Separovic et al. 2013) dans les entrées related avec la relation "isDocumentedBy".
- Licence CC-BY-4.0 tel que recommandé par Cordex (c'est ce qui est/va être sur PAVICS).
- Ajout d'un paragraphe sur l'accès au données sur PAVICS.